### PR TITLE
Start the process of migrating the old patterns over

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .gradle
 .idea
 build/
+.lxpreferences

--- a/README.md
+++ b/README.md
@@ -4,6 +4,25 @@ Entwined software repository picks up where '2squared's Entwined branch leaves o
 
 More information will be added as the project comes into being.
 
+# Gradle LX
+
+Ensure you have java 8 installed and set on your machine
+
+## Lint
+```shell
+$ ./gradlew spotlessApply
+```
+
+## Run the gui
+```shell
+$ ./gradlew run
+```
+
+## Run headless
+```shell
+$ ./gradlew run --args="--headless"
+```
+
 # OLDLX
 
 This directory uses a version of LX studio from many years ago - but it works, and has all the functional

--- a/src/main/java/com/charlesgadeken/entwined/EntwinedGui.java
+++ b/src/main/java/com/charlesgadeken/entwined/EntwinedGui.java
@@ -1,10 +1,11 @@
 package com.charlesgadeken.entwined;
 
-import com.charlesgadeken.entwined.model.Entwined;
 import com.charlesgadeken.entwined.model.Model;
+import com.charlesgadeken.entwined.patterns.general.ExamplePattern;
+import com.charlesgadeken.entwined.patterns.original.DoubleHelix;
+import com.charlesgadeken.entwined.patterns.original.SweepPattern;
 import heronarts.lx.LX;
 import heronarts.lx.LXPlugin;
-import heronarts.lx.model.LXModel;
 import heronarts.lx.studio.LXStudio;
 import java.io.File;
 import processing.core.PApplet;
@@ -35,7 +36,7 @@ public class EntwinedGui extends PApplet implements LXPlugin {
         flags.startMultiThreaded = true;
 
         LX lx = new LX();
-        LXModel model = Model.fromConfigs(lx);
+        Model model = Model.fromConfigs(lx);
 
         new LXStudio(this, flags, model);
         this.surface.setTitle(WINDOW_TITLE);
@@ -49,6 +50,9 @@ public class EntwinedGui extends PApplet implements LXPlugin {
         // available.
 
         // Register custom pattern and effect types
+        lx.registry.addPattern(ExamplePattern.class);
+        lx.registry.addPattern(DoubleHelix.class);
+        lx.registry.addPattern(SweepPattern.class);
     }
 
     public void initializeUI(LXStudio lx, LXStudio.UI ui) {
@@ -60,7 +64,7 @@ public class EntwinedGui extends PApplet implements LXPlugin {
     public void onUIReady(LXStudio lx, LXStudio.UI ui) {
         // At this point, the LX Studio application UI has been built. You may now add
         // additional views and components to the Ui heirarchy.
-        lx.ui.preview.pointCloud.setPointSize(20);
+        //        lx.ui.preview.pointCloud.setPointSize(20);
     }
 
     @Override

--- a/src/main/java/com/charlesgadeken/entwined/Utilities.java
+++ b/src/main/java/com/charlesgadeken/entwined/Utilities.java
@@ -2,12 +2,12 @@ package com.charlesgadeken.entwined;
 
 import java.util.Random;
 
-public class Utils {
+public class Utilities {
     public static float PI = (float) Math.PI;
-    static final float HALF_PI = (float) (Math.PI / 2.0);
-    static final float THIRD_PI = (float) (Math.PI / 3.0);
-    static final float QUARTER_PI = (float) (Math.PI / 4.0);
-    static final float TWO_PI = (float) (2.0 * Math.PI);
+    public static final float HALF_PI = (float) (Math.PI / 2.0);
+    public static final float THIRD_PI = (float) (Math.PI / 3.0);
+    public static final float QUARTER_PI = (float) (Math.PI / 4.0);
+    public static final float TWO_PI = (float) (2.0 * Math.PI);
 
     private static final long millisOffset = System.currentTimeMillis();
 

--- a/src/main/java/com/charlesgadeken/entwined/model/BaseCube.java
+++ b/src/main/java/com/charlesgadeken/entwined/model/BaseCube.java
@@ -1,5 +1,6 @@
 package com.charlesgadeken.entwined.model;
 
+import com.charlesgadeken.entwined.Utilities;
 import heronarts.lx.model.LXModel;
 import heronarts.lx.model.LXPoint;
 import java.awt.geom.Point2D;
@@ -77,9 +78,8 @@ public class BaseCube extends LXModel {
         this.theta =
                 180
                         + 180
-                                / com.charlesgadeken.entwined.Utils.PI
-                                * com.charlesgadeken.entwined.Utils.atan2(
-                                        sculpturePosition.z, sculpturePosition.x);
+                                / Utilities.PI
+                                * Utilities.atan2(sculpturePosition.z, sculpturePosition.x);
     }
 
     void resetTransform() {

--- a/src/main/java/com/charlesgadeken/entwined/model/EntwinedBranch.java
+++ b/src/main/java/com/charlesgadeken/entwined/model/EntwinedBranch.java
@@ -1,6 +1,6 @@
 package com.charlesgadeken.entwined.model;
 
-import com.charlesgadeken.entwined.Utils;
+import com.charlesgadeken.entwined.Utilities;
 import heronarts.lx.transform.LXTransform;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -44,7 +44,7 @@ public class EntwinedBranch {
         zKeyPoints[0] = branchLength * (-0.05);
         List<Vec3D> _availableMountingPoints = new ArrayList<Vec3D>();
         LXTransform transform = new LXTransform();
-        transform.rotateY(rotationalPosition * 45 * (Utils.PI / 180));
+        transform.rotateY(rotationalPosition * 45 * (Utilities.PI / 180));
         double newX = xKeyPoints[0] + 2;
         while (newX < xKeyPoints[NUM_KEYPOINTS - 1]) {
             int keyPointIndex = 0;

--- a/src/main/java/com/charlesgadeken/entwined/model/Geometry.java
+++ b/src/main/java/com/charlesgadeken/entwined/model/Geometry.java
@@ -1,6 +1,6 @@
 package com.charlesgadeken.entwined.model;
 
 public class Geometry {
-    static final int INCHES = 1;
-    static final int FEET = 12 * INCHES;
+    public static final int INCHES = 1;
+    public static final int FEET = 12 * INCHES;
 }

--- a/src/main/java/com/charlesgadeken/entwined/model/Shrub.java
+++ b/src/main/java/com/charlesgadeken/entwined/model/Shrub.java
@@ -1,5 +1,6 @@
 package com.charlesgadeken.entwined.model;
 
+import com.charlesgadeken.entwined.Utilities;
 import com.charlesgadeken.entwined.model.config.ShrubCubeConfig;
 import heronarts.lx.LX;
 import heronarts.lx.model.LXPoint;
@@ -77,7 +78,7 @@ public class Shrub extends LXModelInterceptor {
             this.lx = lx;
             shrubTransform = new LXTransform();
             shrubTransform.translate(x, 0, z);
-            shrubTransform.rotateY(ry * com.charlesgadeken.entwined.Utils.PI / 180);
+            shrubTransform.rotateY(ry * Utilities.PI / 180);
             for (int i = 0; i < NUM_CLUSTERS_IN_SHRUB; i++) {
                 shrubClusters.add(new EntwinedCluster(i));
             }

--- a/src/main/java/com/charlesgadeken/entwined/model/Tree.java
+++ b/src/main/java/com/charlesgadeken/entwined/model/Tree.java
@@ -1,5 +1,6 @@
 package com.charlesgadeken.entwined.model;
 
+import com.charlesgadeken.entwined.Utilities;
 import com.charlesgadeken.entwined.model.config.CubeConfig;
 import heronarts.lx.LX;
 import heronarts.lx.model.LXPoint;
@@ -84,7 +85,7 @@ public class Tree extends LXModelInterceptor {
             super(lx, "Tree");
             transform = new LXTransform();
             transform.translate(x, 0, z);
-            transform.rotateY(ry * com.charlesgadeken.entwined.Utils.PI / 180);
+            transform.rotateY(ry * Utilities.PI / 180);
             for (int i = 0; i < canopyMajorLengths.length; i++) {
                 treeLayers.add(new EntwinedLayer(canopyMajorLengths[i], i, layerBaseHeights[i]));
             }

--- a/src/main/java/com/charlesgadeken/entwined/patterns/EntwinedBasePattern.java
+++ b/src/main/java/com/charlesgadeken/entwined/patterns/EntwinedBasePattern.java
@@ -1,0 +1,34 @@
+package com.charlesgadeken.entwined.patterns;
+
+import com.charlesgadeken.entwined.model.Model;
+import com.charlesgadeken.entwined.triggers.ParameterTriggerableAdapter;
+import heronarts.lx.LX;
+import heronarts.lx.pattern.LXPattern;
+
+public abstract class EntwinedBasePattern extends LXPattern {
+    ParameterTriggerableAdapter parameterTriggerableAdapter;
+    String readableName;
+
+    protected final Model model;
+
+    protected EntwinedBasePattern(LX lx) {
+        super(lx);
+        model = (Model) lx.getModel();
+    }
+
+    void onTriggerableModeEnabled() {
+        getChannel().fader.setValue(0);
+        parameterTriggerableAdapter = getParameterTriggerableAdapter();
+        parameterTriggerableAdapter.addOutputTriggeredListener(
+                parameter -> setCallRun(parameter.getValue() != 0));
+        setCallRun(false);
+    }
+
+    void setCallRun(boolean callRun) {
+        getChannel().enabled.setValue(callRun);
+    }
+
+    ParameterTriggerableAdapter getParameterTriggerableAdapter() {
+        return new ParameterTriggerableAdapter(lx, getChannel().fader);
+    }
+}

--- a/src/main/java/com/charlesgadeken/entwined/patterns/general/ExamplePattern.java
+++ b/src/main/java/com/charlesgadeken/entwined/patterns/general/ExamplePattern.java
@@ -1,0 +1,22 @@
+package com.charlesgadeken.entwined.patterns.general;
+
+import com.charlesgadeken.entwined.patterns.EntwinedBasePattern;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.model.LXPoint;
+
+@LXCategory("Example")
+public class ExamplePattern extends EntwinedBasePattern {
+
+    public ExamplePattern(LX lx) {
+        super(lx);
+    }
+
+    @Override
+    protected void run(double deltaMs) {
+        for (LXPoint p : model.points) {
+            colors[p.index] = LXColor.hsb(240, 100, 100);
+        }
+    }
+}

--- a/src/main/java/com/charlesgadeken/entwined/patterns/original/DoubleHelix.java
+++ b/src/main/java/com/charlesgadeken/entwined/patterns/original/DoubleHelix.java
@@ -1,0 +1,48 @@
+package com.charlesgadeken.entwined.patterns.original;
+
+import com.charlesgadeken.entwined.Utilities;
+import com.charlesgadeken.entwined.model.BaseCube;
+import com.charlesgadeken.entwined.patterns.EntwinedBasePattern;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.modulator.SawLFO;
+import heronarts.lx.modulator.SinLFO;
+import heronarts.lx.utils.LXUtils;
+
+@LXCategory("Original")
+public class DoubleHelix extends EntwinedBasePattern {
+
+    final SinLFO rate = new SinLFO(400, 3000, 11000);
+    final SawLFO theta = new SawLFO(0, 180, rate);
+    final SinLFO coil = new SinLFO(0.2, 2, 13000);
+
+    public DoubleHelix(LX lx) {
+        super(lx);
+        addModulator(rate).start();
+        addModulator(theta).start();
+        addModulator(coil).start();
+    }
+
+    @Override
+    public void run(double deltaMs) {
+        if (getChannel().fader.getNormalized() == 0) return;
+
+        for (BaseCube cube : model.baseCubes) {
+            float coilf = coil.getValuef() * (cube.cy - model.cy);
+            colors[cube.index] =
+                    lx.hsb(
+                            lx.engine.palette.getHuef()
+                                    + .4f * Utilities.abs(cube.transformedY - model.cy)
+                                    + .2f * Utilities.abs(cube.transformedTheta - 180),
+                            100,
+                            Utilities.max(
+                                    0,
+                                    100
+                                            - 2
+                                                    * LXUtils.wrapdistf(
+                                                            cube.transformedTheta,
+                                                            theta.getValuef() + coilf,
+                                                            180)));
+        }
+    }
+}

--- a/src/main/java/com/charlesgadeken/entwined/patterns/original/SweepPattern.java
+++ b/src/main/java/com/charlesgadeken/entwined/patterns/original/SweepPattern.java
@@ -1,0 +1,76 @@
+package com.charlesgadeken.entwined.patterns.original;
+
+import com.charlesgadeken.entwined.Utilities;
+import com.charlesgadeken.entwined.model.BaseCube;
+import com.charlesgadeken.entwined.model.Geometry;
+import com.charlesgadeken.entwined.patterns.EntwinedBasePattern;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.modulator.SawLFO;
+import heronarts.lx.modulator.SinLFO;
+import heronarts.lx.parameter.BoundedParameter;
+import heronarts.lx.parameter.LXParameter;
+
+@LXCategory("Original")
+public class SweepPattern extends EntwinedBasePattern {
+
+    final SinLFO speedMod = new SinLFO(3000, 9000, 5400);
+    final SinLFO yPos = new SinLFO(model.yMin, model.yMax, speedMod);
+    final SinLFO width = new SinLFO("WIDTH", 2 * Geometry.FEET, 20 * Geometry.FEET, 19000);
+
+    final SawLFO offset = new SawLFO(0, Utilities.TWO_PI, 9000);
+
+    final BoundedParameter amplitude =
+            new BoundedParameter("AMP", 10 * Geometry.FEET, 0, 20 * Geometry.FEET);
+    final BoundedParameter speed = new BoundedParameter("SPEED", 1, 0, 3);
+    final BoundedParameter height = new BoundedParameter("HEIGHT", 0, -300, 300);
+    final SinLFO amp = new SinLFO(0, amplitude, 5000);
+
+    public SweepPattern(LX lx) {
+        super(lx);
+        addModulator(speedMod).start();
+        addModulator(yPos).start();
+        addModulator(width).start();
+        addParameter("sweepPattern/amplitude", amplitude);
+        addParameter("sweepPattern/speed", speed);
+        addParameter("sweepPattern/height", height);
+        addModulator(amp).start();
+        addModulator(offset).start();
+    }
+
+    public void onParameterChanged(LXParameter parameter) {
+        super.onParameterChanged(parameter);
+        if (parameter == speed) {
+            float speedVar = 1 / speed.getValuef();
+            speedMod.setRange(9000 * speedVar, 5400 * speedVar);
+        }
+    }
+
+    @Override
+    public void run(double deltaMs) {
+        if (getChannel().fader.getNormalized() == 0) return;
+
+        for (BaseCube cube : model.baseCubes) {
+            float yp =
+                    yPos.getValuef()
+                            + amp.getValuef()
+                                    * Utilities.sin(
+                                            (cube.cx - model.cx) * .01f + offset.getValuef());
+            colors[cube.index] =
+                    lx.hsb(
+                            (lx.engine.palette.getHuef()
+                                            + Utilities.abs(cube.x - model.cx) * .2f
+                                            + cube.cz * .1f
+                                            + cube.cy * .1f)
+                                    % 360,
+                            Utilities.constrain(
+                                    Utilities.abs(cube.transformedY - model.cy), 0, 100),
+                            Utilities.max(
+                                    0,
+                                    100
+                                            - (100 / width.getValuef())
+                                                    * Utilities.abs(
+                                                            cube.cy - yp - height.getValuef())));
+        }
+    }
+}

--- a/src/main/java/com/charlesgadeken/entwined/triggers/ParameterTriggerableAdapter.java
+++ b/src/main/java/com/charlesgadeken/entwined/triggers/ParameterTriggerableAdapter.java
@@ -1,0 +1,78 @@
+package com.charlesgadeken.entwined.triggers;
+
+import heronarts.lx.LX;
+import heronarts.lx.LXLoopTask;
+import heronarts.lx.modulator.DampedParameter;
+import heronarts.lx.parameter.*;
+
+public class ParameterTriggerableAdapter implements Triggerable, LXLoopTask {
+
+    private final BooleanParameter triggeredEventParameter = new BooleanParameter("ANON");
+    private final DampedParameter triggeredEventDampedParameter =
+            new DampedParameter(triggeredEventParameter, 2);
+    private final BooleanParameter isDampening = new BooleanParameter("ANON");
+    private double strength;
+
+    private final LXNormalizedParameter enabledParameter;
+    private final double offValue;
+    private final double onValue;
+
+    public ParameterTriggerableAdapter(LX lx, CompoundParameter enabledParameter) {
+        this(lx, enabledParameter, 0, 1);
+    }
+
+    ParameterTriggerableAdapter(
+            LX lx, LXNormalizedParameter enabledParameter, double offValue, double onValue) {
+        this.enabledParameter = enabledParameter;
+        this.offValue = offValue;
+        this.onValue = onValue;
+
+        lx.engine.addLoopTask(this);
+        lx.engine.addLoopTask(triggeredEventDampedParameter.start());
+    }
+
+    public void loop(double deltaMs) {
+        if (isDampening.isOn()) {
+            enabledParameter.setValue(
+                    (onValue - offValue) * strength * triggeredEventDampedParameter.getValue()
+                            + offValue);
+            if (triggeredEventDampedParameter.getValue() == triggeredEventParameter.getValue()) {
+                isDampening.setValue(false);
+            }
+        } else {
+            if (triggeredEventDampedParameter.getValue() != triggeredEventParameter.getValue()) {
+                enabledParameter.setValue(
+                        (onValue - offValue) * strength * triggeredEventDampedParameter.getValue()
+                                + offValue);
+                isDampening.setValue(true);
+            }
+        }
+    }
+
+    public boolean isTriggered() {
+        return triggeredEventParameter.isOn();
+    }
+
+    public void addOutputTriggeredListener(final LXParameterListener listener) {
+        isDampening.addListener(
+                new LXParameterListener() {
+                    public void onParameterChanged(LXParameter parameter) {
+                        listener.onParameterChanged(triggeredEventDampedParameter);
+                    }
+                });
+    }
+
+    public void onTriggered(float strength) {
+        this.strength = strength;
+        triggeredEventDampedParameter.setValue(
+                (enabledParameter.getValue() - offValue) / (onValue - offValue));
+        // println((enabledParameter.getValue() - offValue) / (onValue - offValue));
+        triggeredEventParameter.setValue(true);
+    }
+
+    public void onRelease() {
+        triggeredEventDampedParameter.setValue(
+                (enabledParameter.getValue() - offValue) / (onValue - offValue));
+        triggeredEventParameter.setValue(false);
+    }
+}

--- a/src/main/java/com/charlesgadeken/entwined/triggers/Triggerable.java
+++ b/src/main/java/com/charlesgadeken/entwined/triggers/Triggerable.java
@@ -1,0 +1,13 @@
+package com.charlesgadeken.entwined.triggers;
+
+import heronarts.lx.parameter.LXParameterListener;
+
+interface Triggerable {
+    boolean isTriggered();
+
+    void onTriggered(float strength);
+
+    void onRelease();
+
+    void addOutputTriggeredListener(LXParameterListener listener);
+}

--- a/src/test/java/com/charlesgadeken/entwined/patterns/general/ExamplePatternTest.java
+++ b/src/test/java/com/charlesgadeken/entwined/patterns/general/ExamplePatternTest.java
@@ -1,0 +1,17 @@
+package com.charlesgadeken.entwined.patterns.general;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.charlesgadeken.entwined.model.Model;
+import heronarts.lx.LX;
+import org.junit.jupiter.api.Test;
+
+class ExamplePatternTest {
+
+    @Test
+    void testBuild() {
+        LX lx = new LX();
+        Model model = Model.fromConfigs(lx);
+        new ExamplePattern(new LX(model));
+    }
+}


### PR DESCRIPTION
Here we take the legacy TSPattern and use that to create the `EntwinedBasePattern`, while trying to port of the TriggerableAdapter to the best of my ability.

* It appears that the `getBaseHuef` is now apart of LXPallet which is available via the LXEngine?
* I feel like... a lot of things in here around Transitions/Layers/Triggers|Parameters are baked into "modern" LX these days. So After awhile we may find that we do not need a bunch of this work?

# Also
- Renamed Utils -> Utilities.. as Utils is some builtin?
- Migrated the sweepPattern
- Migrated the DoubleHelix pattern
- Added an ExamplePattern with a test to ensure it compiles/builds

# Eyecandy
![image](https://user-images.githubusercontent.com/4576814/99627917-0bae7200-29ea-11eb-8dd4-82404ad925dc.png)

