### PR TITLE
Add new interactive color effects Candy Chaos, Rainbow, and White

### DIFF
--- a/oldlx/Trees/CanopyController.java
+++ b/oldlx/Trees/CanopyController.java
@@ -279,13 +279,26 @@ class CanopyController {
   			case "lightning":  		
   			case "bass-slam":
   			case "rain":
-  			case "color-burst":	
+				engine.interactiveHSVEffect.resetPiece(pieceId);
+				break;
+
+			case "white":
+				engine.interactiveHSVEffect.resetPiece(pieceId);
+				engine.interactiveDesaturationEffect.onTriggeredPiece(pieceId);
+			case "rainbow":
+				engine.interactiveHSVEffect.resetPiece(pieceId);
+				engine.interactiveRainbowEffect.onTriggeredPiece(pieceId);
+				break;
+			case "candy-chaos":
+				engine.interactiveHSVEffect.resetPiece(pieceId);
+				engine.interactiveCandyChaosEffect.onTriggeredPiece(pieceId);
+				break;
   			case "fire":
   				engine.interactiveHSVEffect.resetPiece(pieceId);
   				engine.interactiveFireEffect.onTriggeredPiece(pieceId);
   				break;
   			default:
-  				engine.log("unknown trigger name "+triggerName);
+  				engine.log("unknown trigger name " + triggerName);
   				break;
   		}
 	} catch (Exception e) {

--- a/oldlx/Trees/Engine.java
+++ b/oldlx/Trees/Engine.java
@@ -93,6 +93,9 @@ abstract class Engine {
   final CanopyController canopyController;
   final InteractiveHSVEffect interactiveHSVEffect;
   final InteractiveFireEffect interactiveFireEffect;
+  final InteractiveCandyChaosEffect interactiveCandyChaosEffect;
+  final InteractiveRainbowEffect interactiveRainbowEffect;
+  final InteractiveDesaturationEffect interactiveDesaturationEffect;
 
   // breadcrumb regarding channelTreeLevels and channelShrubLevels
   // these are controllers which should be used on a shrub-by-shrub basis to allow
@@ -181,10 +184,32 @@ abstract class Engine {
     interactiveHSVEffect = new InteractiveHSVEffect(lx);
     lx.addEffect(interactiveHSVEffect); /* want this one "on top" of everything else... is it? */
     interactiveHSVEffect.enable();
+
     // this fire effect, going to make it more generic, but make it work at all now
     interactiveFireEffect = new InteractiveFireEffect(lx, model);
     Effect[] fireEffects = interactiveFireEffect.getEffects();
     for (Effect effect : fireEffects) {
+      lx.addEffect(effect);
+      effect.enable();
+    }
+
+    interactiveCandyChaosEffect = new InteractiveCandyChaosEffect(lx, model);
+    Effect[] candyChaosEffects = interactiveCandyChaosEffect.getEffects();
+    for (Effect effect: candyChaosEffects) {
+      lx.addEffect(effect);
+      effect.enable();
+    }
+
+    interactiveRainbowEffect = new InteractiveRainbowEffect(lx, model);
+    Effect[] interactiveRainbowEffects = interactiveRainbowEffect.getEffects();
+    for (Effect effect: interactiveRainbowEffects) {
+      lx.addEffect(effect);
+      effect.enable();
+    }
+
+    interactiveDesaturationEffect = new InteractiveDesaturationEffect(lx, model);
+    Effect[] interactiveDesaturationEffects = interactiveDesaturationEffect.getEffects();
+    for (Effect effect: interactiveDesaturationEffects) {
       lx.addEffect(effect);
       effect.enable();
     }

--- a/oldlx/Trees/Patterns.java
+++ b/oldlx/Trees/Patterns.java
@@ -293,6 +293,10 @@ class ColorEffect extends Effect {
   private final DampedParameter rainbowd = new DampedParameter(rainbow, 1);
   
   private float[] hsb = new float[3];
+
+  // if set to a value >= 0, the effects are limited to only
+  // the piece with that index (used for interactive effects)
+  protected int pieceIndex = -1;
   
   ColorEffect(LX lx) {
     super(lx);
@@ -317,6 +321,10 @@ class ColorEffect extends Effect {
     if (desatf > 0 || huef > 0 || sharpf > 0 || softf > 0 || monof > 0 || rainbowf > 0) {
       float pSharp = 1/(1-.99f*sharpf);
       for (int i = 0; i < colors.length; ++i) {
+        BaseCube cube = model.baseCubes.get(i);
+        // if we're only applying this effect to a given pieceIndex, filter out and don't set colors on other cubes
+        if (pieceIndex >= 0 && cube.pieceIndex != pieceIndex) continue;
+
         float b = LXColor.b(colors[i]) / 100.f;
         float bOrig = b;
         if (sharpf > 0) {

--- a/oldlx/Trees/Patterns_Interactive.java
+++ b/oldlx/Trees/Patterns_Interactive.java
@@ -451,9 +451,199 @@ class InteractiveFireEffect {
     }
 
   }
+}
+
+// add color effects for Canopy use
+
+class InteractiveCandyChaosEffect {
+  final public InteractiveCandyChaos pieceEffects[];
+
+  final int nPieces;
+  final Map<String, Integer> pieceIdMap;
+  
+  // constructor
+  InteractiveCandyChaosEffect(LX lx, Model model) {
+
+    // Need to know the different pieces that exist, and be able to look them up by name
+    //
+    int nPieces = model.pieceIds.length;
+    this.nPieces = nPieces;
+    this.pieceIdMap = model.pieceIdMap;
+
+    pieceEffects = new InteractiveCandyChaos[nPieces];
+    for (int pieceIndex=0 ; pieceIndex<nPieces ; pieceIndex++) {
+      pieceEffects[pieceIndex] = new InteractiveCandyChaos(lx, pieceIndex); 
+    }
+  }
+
+  Effect[] getEffects() {
+    return ( pieceEffects );
+  }
+
+  void onTriggeredPiece(String pieceId) {
+    Integer pieceIndex_o = pieceIdMap.get(pieceId);
+    if (pieceIndex_o == null) return;
+    pieceEffects[(int) pieceIndex_o ].onTriggered();
+  }
 
 
+  class InteractiveCandyChaos extends CandyTextureEffect {
+    private boolean triggered;
+    private long triggerEndMillis; // when to un-enable if enabled
+    
+    InteractiveCandyChaos(LX lx, int pieceIndex) {
+      super(lx);
 
+      // turn the effect on 100%
+      super.amount.setValue(1);
+
+      this.pieceIndex = pieceIndex;
+      this.triggered = false;
+    }
+
+    public void run(double deltaMs) {
+      if (triggered == false) return;
+      if (System.currentTimeMillis() > triggerEndMillis) onRelease();
+
+      super.run(deltaMs);
+    }
+
+    public void onTriggered() {
+      triggered = true;
+      triggerEndMillis = System.currentTimeMillis() + 3000;
+    };
+
+    public void onRelease() {
+      triggered = false;
+    }
+  }
 }
 
 
+class InteractiveRainbowEffect {
+  final public InteractiveRainbow pieceEffects[];
+
+  final int nPieces;
+  final Map<String, Integer> pieceIdMap;
+  
+  // constructor
+  InteractiveRainbowEffect(LX lx, Model model) {
+
+    // Need to know the different pieces that exist, and be able to look them up by name
+    //
+    int nPieces = model.pieceIds.length;
+    this.nPieces = nPieces;
+    this.pieceIdMap = model.pieceIdMap;
+
+    pieceEffects = new InteractiveRainbow[nPieces];
+    for (int pieceIndex=0 ; pieceIndex<nPieces ; pieceIndex++) {
+      pieceEffects[pieceIndex] = new InteractiveRainbow(lx, pieceIndex); 
+    }
+  }
+
+  Effect[] getEffects() {
+    return ( pieceEffects );
+  }
+
+  void onTriggeredPiece(String pieceId) {
+    Integer pieceIndex_o = pieceIdMap.get(pieceId);
+    if (pieceIndex_o == null) return;
+    pieceEffects[(int) pieceIndex_o ].onTriggered();
+  }
+
+
+  class InteractiveRainbow extends CandyCloudTextureEffect {
+    private boolean triggered;
+    private long triggerEndMillis; // when to un-enable if enabled
+    
+    InteractiveRainbow(LX lx, int pieceIndex) {
+      super(lx);
+
+      // turn the effect on 100%
+      super.amount.setValue(1);
+
+      this.pieceIndex = pieceIndex;
+      this.triggered = false;
+    }
+
+    public void run(double deltaMs) {
+      if (triggered == false) return;
+      if (System.currentTimeMillis() > triggerEndMillis) onRelease();
+
+      super.run(deltaMs);
+    }
+
+    public void onTriggered() {
+      triggered = true;
+      triggerEndMillis = System.currentTimeMillis() + 3000;
+    };
+
+    public void onRelease() {
+      triggered = false;
+    }
+  }
+}
+
+class InteractiveDesaturationEffect {
+  final public InteractiveDesaturation pieceEffects[];
+
+  final int nPieces;
+  final Map<String, Integer> pieceIdMap;
+  
+  // constructor
+  InteractiveDesaturationEffect(LX lx, Model model) {
+
+    // Need to know the different pieces that exist, and be able to look them up by name
+    //
+    int nPieces = model.pieceIds.length;
+    this.nPieces = nPieces;
+    this.pieceIdMap = model.pieceIdMap;
+
+    pieceEffects = new InteractiveDesaturation[nPieces];
+    for (int pieceIndex=0 ; pieceIndex<nPieces ; pieceIndex++) {
+      pieceEffects[pieceIndex] = new InteractiveDesaturation(lx, pieceIndex); 
+    }
+  }
+
+  Effect[] getEffects() {
+    return ( pieceEffects );
+  }
+
+  void onTriggeredPiece(String pieceId) {
+    Integer pieceIndex_o = pieceIdMap.get(pieceId);
+    if (pieceIndex_o == null) return;
+    pieceEffects[(int) pieceIndex_o ].onTriggered();
+  }
+
+
+  class InteractiveDesaturation extends ColorEffect {
+    private boolean triggered;
+    private long triggerEndMillis; // when to un-enable if enabled
+    
+    InteractiveDesaturation(LX lx, int pieceIndex) {
+      super(lx);
+
+      // turn the effect on 100%
+      super.desaturation.setValue(1);
+
+      this.pieceIndex = pieceIndex;
+      this.triggered = false;
+    }
+
+    public void run(double deltaMs) {
+      if (triggered == false) return;
+      if (System.currentTimeMillis() > triggerEndMillis) onRelease();
+
+      super.run(deltaMs);
+    }
+
+    public void onTriggered() {
+      triggered = true;
+      triggerEndMillis = System.currentTimeMillis() + 3000;
+    };
+
+    public void onRelease() {
+      triggered = false;
+    }
+  }
+}

--- a/oldlx/Trees/Patterns_KyleFleming.java
+++ b/oldlx/Trees/Patterns_KyleFleming.java
@@ -1159,6 +1159,10 @@ class CandyTextureEffect extends Effect {
 
   double time = 0;
 
+  // if set to a value >= 0, the effects are limited to only
+  // the piece with that index (used for interactive effects)
+  protected int pieceIndex = -1;
+
   CandyTextureEffect(LX lx) {
     super(lx);
   }
@@ -1168,6 +1172,11 @@ class CandyTextureEffect extends Effect {
       time += deltaMs;
       for (int i = 0; i < colors.length; i++) {
         int oldColor = colors[i];
+        BaseCube cube = model.baseCubes.get(i);
+
+        // if we're only applying this effect to a given pieceIndex, filter out and don't set colors on other cubes
+        if (pieceIndex >= 0 && cube.pieceIndex != pieceIndex) continue;
+
         float newHue = i * 127 + 9342 + (float)time % 360;
         int newColor = lx.hsb(newHue, 100, 100);
         int blendedColor = LXColor.lerp(oldColor, newColor, amount.getValuef());
@@ -1185,6 +1194,10 @@ class CandyCloudTextureEffect extends Effect {
   final double scale = 2400;
   final double speed = 1.0f / 5000;
 
+  // if set to a value >= 0, the effects are limited to only
+  // the piece with that index (used for interactive effects)
+  protected int pieceIndex = -1;
+
   CandyCloudTextureEffect(LX lx) {
     super(lx);
   }
@@ -1195,6 +1208,9 @@ class CandyCloudTextureEffect extends Effect {
       for (int i = 0; i < colors.length; i++) {
         int oldColor = colors[i];
         BaseCube cube = model.baseCubes.get(i);
+
+        // if we're only applying this effect to a given pieceIndex, filter out and don't set colors on other cubes
+        if (pieceIndex >= 0 && cube.pieceIndex != pieceIndex) continue;
 
         double adjustedX = cube.x / scale;
         double adjustedY = cube.y / scale;


### PR DESCRIPTION
**Goal:** add more one-shot triggerable effects to make Canopy a bit more interesting (i.e. not just fire). Since adding new _patterns_ seemed like a big hassle and I was blocked after our previous discussions, I pivoted to adding new _effects_ instead which I still think is cool.

This PR adds the new interactive effects Candy Chaos, Rainbow, and White.

It follows the existing pattern set by InteractiveFireEffect almost exactly, and mostly just makes wrapper interactive effects for each of the three. These are basically copy-pasta currently, I think that's janky and ideally these would be much DRYer, but also I wanted to get this done tonight and I don't know a ton of Java so 🤷‍♀️ it's what I got.

There's a [companion PR for this over at entwined-canopy](https://github.com/squaredproject/entwined-canopy/pull/26) which should be merged _after_ this PR is merged. That's a simple change that just adds buttons, and then tweaks the controls to vary them for each piece type at GGP.