### PR TITLE
Fix piece naming on fairy circles and fallen tree to match Canopy

### DIFF
--- a/chromatik/installations/ggp-2022/bench.json
+++ b/chromatik/installations/ggp-2022/bench.json
@@ -4,7 +4,7 @@
 			"x" : 40,
 			"z" : 696,
 			"cubeSizeIndex": 0,
-			"pieceId" : "bench-1",
+			"pieceId" : "fallen-log",
 			"ipAddress" : "10.0.0.160"
 	}
 ]

--- a/chromatik/installations/ggp-2022/fairy_circles.json
+++ b/chromatik/installations/ggp-2022/fairy_circles.json
@@ -4,7 +4,7 @@
 			"x" : 540,
 			"z" : 300,
 			"radius" : 120,
-			"pieceId" : "fairy-01",
+			"pieceId" : "baby-1",
 			"cubeSizeIndex" : 0,
 			"clustersPerNdb" : 5,
 			"ipAddresses" : ["10.0.0.141", "10.0.0.147"]
@@ -15,7 +15,7 @@
 			"z" : -540,
 			"radius" : 60,
 			"degrees" : 220,
-			"pieceId" : "fairy-02",
+			"pieceId" : "baby-2",
 			"cubeSizeIndex" : 0,
 			"clustersPerNdb" : 3,
 			"ipAddresses" : ["10.0.0.144"]
@@ -26,7 +26,7 @@
 			"z" : -660,
 			"radius" : 60,
 			"degrees" : 220,
-			"pieceId" : "fairy-03",
+			"pieceId" : "baby-3",
 			"cubeSizeIndex" : 0,
 			"clustersPerNdb" : 3,
 			"ipAddresses" : ["10.0.0.130"]
@@ -37,7 +37,7 @@
 			"z" : 0,
 			"radius" : 60,
 			"degrees" : 220,
-			"pieceId" : "fairy-04",
+			"pieceId" : "baby-4",
 			"cubeSizeIndex" : 0,
 			"clustersPerNdb" : 3,
 			"ipAddresses" : ["10.0.0.165"]
@@ -48,7 +48,7 @@
 			"z" : 444,
 			"radius" : 60,
 			"degrees" : 220,
-			"pieceId" : "fairy-05",
+			"pieceId" : "baby-5",
 			"cubeSizeIndex" : 0,
 			"clustersPerNdb" : 3,
 			"ipAddresses" : ["10.0.0.132"]
@@ -59,7 +59,7 @@
 			"z" : 1020,
 			"radius" : 60,
 			"degrees" : 220,
-			"pieceId" : "fairy-06",
+			"pieceId" : "baby-6",
 			"cubeSizeIndex" : 0,
 			"clustersPerNdb" : 3,
 			"ipAddresses" : ["10.0.0.133"]
@@ -70,7 +70,7 @@
 			"z" : 876,
 			"radius" : 60,
 			"degrees" : 220,
-			"pieceId" : "fairy-07",
+			"pieceId" : "baby-7",
 			"cubeSizeIndex" : 0,
 			"clustersPerNdb" : 3,
 			"ipAddresses" : ["10.0.0.140"]
@@ -81,7 +81,7 @@
 			"z" : 1200,
 			"radius" : 60,
 			"degrees" : 220,
-			"pieceId" : "fairy-08",
+			"pieceId" : "baby-8",
 			"cubeSizeIndex" : 0,
 			"clustersPerNdb" : 3,
 			"ipAddresses" : ["10.0.0.146"]
@@ -92,7 +92,7 @@
 			"z" : 1080,
 			"radius" : 60,
 			"degrees" : 220,
-			"pieceId" : "fairy-09",
+			"pieceId" : "baby-9",
 			"cubeSizeIndex" : 0,
 			"clustersPerNdb" : 3,
 			"ipAddresses" : ["10.0.0.164"]
@@ -103,7 +103,7 @@
 			"z" : 540,
 			"radius" : 60,
 			"degrees" : 220,
-			"pieceId" : "fairy-10",
+			"pieceId" : "baby-10",
 			"cubeSizeIndex" : 0,
 			"clustersPerNdb" : 3,
 			"ipAddresses" : ["10.0.0.149"]


### PR DESCRIPTION
Looks like the fairy circle / fallen tree piece IDs don't match Canopy. While one could debate which name was better, we already printed QR codes that use the Canopy piece IDs so we're locked for this season :)